### PR TITLE
Refactoring construct_hivdb_asi from java to python

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,8 @@ verify_ssl = true
 [packages]
 pyyaml = "*"
 pymysql = "*"
-hivdb-graphql = {editable = true,path = "/Users/philip/gitrepo/hivdb-graphql"}
+hivdb-graphql = {editable = true,path = "../hivdb-graphql"}
+lxml = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ddfbc1560bdb7ed22d4d8720bdfcfef0a65144064eb6ed1552e39cedc3018131"
+            "sha256": "f7a97b5f450d051e4d0c92cfd4566ef25effedce026115207e5483ea997e945c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -40,10 +40,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
-                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
+                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
+                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
             ],
-            "version": "==2019.9.11"
+            "version": "==2019.11.28"
         },
         "chardet": {
             "hashes": [
@@ -116,10 +116,10 @@
         },
         "graphql-core": {
             "hashes": [
-                "sha256:889e869be5574d02af77baf1f30b5db9ca2959f1c9f5be7b2863ead5a3ec6181",
-                "sha256:9462e22e32c7f03b667373ec0a84d95fba10e8ce2ead08f29fbddc63b671b0c1"
+                "sha256:535585f0dc451fd3f3ef7df34781856e26d9effd5c50e677bae3cabfb883abc7",
+                "sha256:c1b1a9f57434ef65bf5379c8a6b53755c2e7a38bd77bf01687f51c3361ac041b"
             ],
-            "version": "==2.1"
+            "version": "==2.3"
         },
         "graphql-relay": {
             "hashes": [
@@ -129,10 +129,9 @@
         },
         "graphql-server-core": {
             "hashes": [
-                "sha256:678ee824102b3ed84de7fb618e6d5d01f873e0ff376f8564335ccb4cdc9db07d",
-                "sha256:e5f82add4b3d5580aa1f1e7d9f00e944ad3abe1b65eb337e611d6a77cc20f231"
+                "sha256:04ee90da0322949f7b49ff6905688e3a21a9efbd5a7d7835997e431a0afdbd11"
             ],
-            "version": "==1.1.1"
+            "version": "==1.2.0"
         },
         "gunicorn": {
             "hashes": [
@@ -143,7 +142,7 @@
         },
         "hivdb-graphql": {
             "editable": true,
-            "path": "/Users/philip/gitrepo/hivdb-graphql"
+            "path": "../hivdb-graphql"
         },
         "hivfacts": {
             "hashes": [
@@ -201,6 +200,38 @@
                 "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
             ],
             "version": "==2.10.1"
+        },
+        "lxml": {
+            "hashes": [
+                "sha256:00ac0d64949fef6b3693813fe636a2d56d97a5a49b5bbb86e4cc4cc50ebc9ea2",
+                "sha256:0571e607558665ed42e450d7bf0e2941d542c18e117b1ebbf0ba72f287ad841c",
+                "sha256:0e3f04a7615fdac0be5e18b2406529521d6dbdb0167d2a690ee328bef7807487",
+                "sha256:13cf89be53348d1c17b453867da68704802966c433b2bb4fa1f970daadd2ef70",
+                "sha256:217262fcf6a4c2e1c7cb1efa08bd9ebc432502abc6c255c4abab611e8be0d14d",
+                "sha256:223e544828f1955daaf4cefbb4853bc416b2ec3fd56d4f4204a8b17007c21250",
+                "sha256:277cb61fede2f95b9c61912fefb3d43fbd5f18bf18a14fae4911b67984486f5d",
+                "sha256:3213f753e8ae86c396e0e066866e64c6b04618e85c723b32ecb0909885211f74",
+                "sha256:4690984a4dee1033da0af6df0b7a6bde83f74e1c0c870623797cec77964de34d",
+                "sha256:4fcc472ef87f45c429d3b923b925704aa581f875d65bac80f8ab0c3296a63f78",
+                "sha256:61409bd745a265a742f2693e4600e4dbd45cc1daebe1d5fad6fcb22912d44145",
+                "sha256:678f1963f755c5d9f5f6968dded7b245dd1ece8cf53c1aa9d80e6734a8c7f41d",
+                "sha256:6c6d03549d4e2734133badb9ab1c05d9f0ef4bcd31d83e5d2b4747c85cfa21da",
+                "sha256:6e74d5f4d6ecd6942375c52ffcd35f4318a61a02328f6f1bd79fcb4ffedf969e",
+                "sha256:7b4fc7b1ecc987ca7aaf3f4f0e71bbfbd81aaabf87002558f5bc95da3a865bcd",
+                "sha256:7ed386a40e172ddf44c061ad74881d8622f791d9af0b6f5be20023029129bc85",
+                "sha256:8f54f0924d12c47a382c600c880770b5ebfc96c9fd94cf6f6bdc21caf6163ea7",
+                "sha256:ad9b81351fdc236bda538efa6879315448411a81186c836d4b80d6ca8217cdb9",
+                "sha256:bbd00e21ea17f7bcc58dccd13869d68441b32899e89cf6cfa90d624a9198ce85",
+                "sha256:c3c289762cc09735e2a8f8a49571d0e8b4f57ea831ea11558247b5bdea0ac4db",
+                "sha256:cf4650942de5e5685ad308e22bcafbccfe37c54aa7c0e30cd620c2ee5c93d336",
+                "sha256:cfcbc33c9c59c93776aa41ab02e55c288a042211708b72fdb518221cc803abc8",
+                "sha256:e301055deadfedbd80cf94f2f65ff23126b232b0d1fea28f332ce58137bcdb18",
+                "sha256:ebbfe24df7f7b5c6c7620702496b6419f6a9aa2fd7f005eb731cc80d7b4692b9",
+                "sha256:eff69ddbf3ad86375c344339371168640951c302450c5d3e9936e98d6459db06",
+                "sha256:f6ed60a62c5f1c44e789d2cf14009423cb1646b44a43e40a9cf6a21f077678a1"
+            ],
+            "index": "pypi",
+            "version": "==4.4.2"
         },
         "mako": {
             "hashes": [
@@ -284,10 +315,10 @@
         },
         "parso": {
             "hashes": [
-                "sha256:63854233e1fadb5da97f2744b6b24346d2750b85965e7e399bec1620232797dc",
-                "sha256:666b0ee4a7a1220f65d367617f2cd3ffddff3e205f3f16a0284df30e774c2a9c"
+                "sha256:55cf25df1a35fd88b878715874d2c4dc1ad3f0eebd1e0266a67e1f55efccfbe1",
+                "sha256:5c1f7791de6bd5dbbeac8db0ef5594b36799de198b3f7f7014643b0c5536b9d3"
             ],
-            "version": "==0.5.1"
+            "version": "==0.5.2"
         },
         "pexpect": {
             "hashes": [
@@ -306,10 +337,9 @@
         },
         "promise": {
             "hashes": [
-                "sha256:2ebbfc10b7abf6354403ed785fe4f04b9dfd421eb1a474ac8d187022228332af",
-                "sha256:348f5f6c3edd4fd47c9cd65aed03ac1b31136d375aa63871a57d3e444c85655c"
+                "sha256:dfd18337c523ba4b6a58801c164c1904a9d4d1b1747c7d5dbf45b693a49d93d0"
             ],
-            "version": "==2.2.1"
+            "version": "==2.3"
         },
         "prompt-toolkit": {
             "hashes": [
@@ -358,22 +388,20 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:0113bc0ec2ad727182326b61326afa3d1d8280ae1122493553fd6f4397f33df9",
-                "sha256:01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4",
-                "sha256:5124373960b0b3f4aa7df1707e63e9f109b5263eca5976c66e08b1c552d4eaf8",
-                "sha256:5ca4f10adbddae56d824b2c09668e91219bb178a1eee1faa56af6f99f11bf696",
-                "sha256:7907be34ffa3c5a32b60b95f4d95ea25361c951383a894fec31be7252b2b6f34",
-                "sha256:7ec9b2a4ed5cad025c2278a1e6a19c011c80a3caaac804fd2d329e9cc2c287c9",
-                "sha256:87ae4c829bb25b9fe99cf71fbb2140c448f534e24c998cc60f39ae4f94396a73",
-                "sha256:9de9919becc9cc2ff03637872a440195ac4241c80536632fffeb6a1e25a74299",
-                "sha256:a5a85b10e450c66b49f98846937e8cfca1db3127a9d5d1e31ca45c3d0bef4c5b",
-                "sha256:b0997827b4f6a7c286c01c5f60384d218dca4ed7d9efa945c3e1aa623d5709ae",
-                "sha256:b631ef96d3222e62861443cc89d6563ba3eeb816eeb96b2629345ab795e53681",
-                "sha256:bf47c0607522fdbca6c9e817a6e81b08491de50f3766a7a0e6a5be7905961b41",
-                "sha256:f81025eddd0327c7d4cfe9b62cf33190e1e736cc6e97502b3ec425f574b3e7a8"
+                "sha256:059b2ee3194d718896c0ad077dd8c043e5e909d9180f387ce42012662a4946d6",
+                "sha256:1cf708e2ac57f3aabc87405f04b86354f66799c8e62c28c5fc5f88b5521b2dbf",
+                "sha256:24521fa2890642614558b492b473bee0ac1f8057a7263156b02e8b14c88ce6f5",
+                "sha256:4fee71aa5bc6ed9d5f116327c04273e25ae31a3020386916905767ec4fc5317e",
+                "sha256:70024e02197337533eef7b85b068212420f950319cc8c580261963aefc75f811",
+                "sha256:74782fbd4d4f87ff04159e986886931456a1894c61229be9eaf4de6f6e44b99e",
+                "sha256:940532b111b1952befd7db542c370887a8611660d2b9becff75d39355303d82d",
+                "sha256:cb1f2f5e426dc9f07a7681419fe39cee823bb74f723f36f70399123f439e9b20",
+                "sha256:dbbb2379c19ed6042e8f11f2a2c66d39cceb8aeace421bfc29d085d93eda3689",
+                "sha256:e3a057b7a64f1222b56e47bcff5e4b94c4f61faac04c7c4ecb1985e18caa3994",
+                "sha256:e9f45bd5b92c7974e59bcd2dcc8631a6b6cc380a904725fce7bc08872e691615"
             ],
             "index": "pypi",
-            "version": "==5.1.2"
+            "version": "==5.3"
         },
         "requests": {
             "hashes": [
@@ -384,10 +412,10 @@
         },
         "rx": {
             "hashes": [
-                "sha256:00c4ab3ecd1ab9a55f310d05e20ae7f93d3cdd1150de5c56347e67a1ecd73963",
-                "sha256:c7d168618e3cec35fda9c9c8b5d7f966739df4b1a99b315eae1fc2d7d69e2512"
+                "sha256:13a1d8d9e252625c173dc795471e614eadfe1cf40ffc684e08b8fff0d9748c23",
+                "sha256:7357592bc7e881a95e0c2013b73326f704953301ab551fbc8133a6fadab84105"
             ],
-            "version": "==3.0.1"
+            "version": "==1.6.1"
         },
         "simplegeneric": {
             "hashes": [

--- a/data/mutation-scores-combi.json
+++ b/data/mutation-scores-combi.json
@@ -1,0 +1,2046 @@
+[
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "100I+103N",
+    "drug": "DOR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "101E+181C",
+    "drug": "EFV",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "101E+181C",
+    "drug": "ETR",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "101E+181C",
+    "drug": "NVP",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "101E+184I",
+    "drug": "RPV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "101E+188L",
+    "drug": "ETR",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "101E+190A",
+    "drug": "DOR",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "101E+190A",
+    "drug": "ETR",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "101E+190S",
+    "drug": "DOR",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "101E+190S",
+    "drug": "ETR",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "103N+181C",
+    "drug": "DOR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "103R+179D",
+    "drug": "EFV",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "103R+179D",
+    "drug": "NVP",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "103R+179D",
+    "drug": "RPV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "106A+227L",
+    "drug": "DOR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "106A+227L",
+    "drug": "EFV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "106I+181C",
+    "drug": "DOR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "106I+181C",
+    "drug": "RPV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "106I+190S",
+    "drug": "DOR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "108I+181C",
+    "drug": "DOR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "108I+234I",
+    "drug": "DOR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "138K+184I",
+    "drug": "RPV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "151M+184IV",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "151M+184IV",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "151M+184IV",
+    "drug": "TDF",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "179F+181C",
+    "drug": "ETR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "179F+181C",
+    "drug": "RPV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "179T+181C",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "179T+181C",
+    "drug": "RPV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "181C+190ACSTV",
+    "drug": "DOR",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "181C+190ACSTV",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "181C+190ACSTV",
+    "drug": "RPV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "181CIV+221Y",
+    "drug": "DOR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "181CIV+221Y",
+    "drug": "RPV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "210W+215ACDEILNSV",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "210W+215ACDEILNSV",
+    "drug": "AZT",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "210W+215ACDEILNSV",
+    "drug": "D4T",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "210W+215ACDEILNSV",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "210W+215ACDEILNSV",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "210W+215FY",
+    "drug": "ABC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "210W+215FY",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "210W+215FY",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "210W+215FY",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "210W+215FY",
+    "drug": "FTC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "210W+215FY",
+    "drug": "LMV",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "210W+215FY",
+    "drug": "TDF",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "40F+41L+210W+215FY",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "40F+41L+210W+215FY",
+    "drug": "AZT",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "40F+41L+210W+215FY",
+    "drug": "D4T",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "40F+41L+210W+215FY",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "40F+41L+210W+215FY",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+210W",
+    "drug": "ABC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+210W",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+210W",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+210W",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+210W",
+    "drug": "TDF",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+210W+215FY",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+210W+215FY",
+    "drug": "FTC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+210W+215FY",
+    "drug": "LMV",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+210W+215FY",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+215ACDEILNSV",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+215ACDEILNSV",
+    "drug": "AZT",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+215ACDEILNSV",
+    "drug": "D4T",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+215ACDEILNSV",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+215ACDEILNSV",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+215FY",
+    "drug": "ABC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+215FY",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+215FY",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+215FY",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+215FY",
+    "drug": "FTC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+215FY",
+    "drug": "LMV",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+215FY",
+    "drug": "TDF",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+44AD+210W+215FY",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+44AD+210W+215FY",
+    "drug": "AZT",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+44AD+210W+215FY",
+    "drug": "D4T",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+44AD+210W+215FY",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+44AD+210W+215FY",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+67EGN+215FY",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+67EGN+215FY",
+    "drug": "AZT",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+67EGN+215FY",
+    "drug": "D4T",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+67EGN+215FY",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+67EGN+215FY",
+    "drug": "FTC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+67EGN+215FY",
+    "drug": "LMV",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "41L+67EGN+215FY",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "65R+151M",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "65R+151M",
+    "drug": "TDF",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "67EGN+215FY+219ENQR",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "67EGN+215FY+219ENQR",
+    "drug": "AZT",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "67EGN+215FY+219ENQR",
+    "drug": "D4T",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "67EGN+215FY+219ENQR",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "67EGN+215FY+219ENQR",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "67EGN+70R+184IV+219ENQR",
+    "drug": "ABC",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "67EGN+70R+219ENQR",
+    "drug": "ABC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "67EGN+70R+219ENQR",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "67EGN+70R+219ENQR",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "67EGN+70R+219ENQR",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "67EGN+70R+219ENQR",
+    "drug": "FTC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "67EGN+70R+219ENQR",
+    "drug": "LMV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "67EGN+70R+219ENQR",
+    "drug": "TDF",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "70EGNQST+184IV",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "70EGNQST+184IV",
+    "drug": "TDF",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "70R+215FY",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "70R+215FY",
+    "drug": "AZT",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "70R+215FY",
+    "drug": "D4T",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "70R+215FY",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "70R+215FY",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "74IV+184IV",
+    "drug": "ABC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "77L+116Y+151M",
+    "drug": "ABC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "77L+116Y+151M",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "77L+116Y+151M",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "77L+116Y+151M",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "77L+116Y+151M",
+    "drug": "FTC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "77L+116Y+151M",
+    "drug": "LMV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "rule": "77L+116Y+151M",
+    "drug": "TDF",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "98G+181C",
+    "drug": "DOR",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "98G+181C",
+    "drug": "EFV",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "98G+181C",
+    "drug": "ETR",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "98G+181C",
+    "drug": "NVP",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "98G+181C",
+    "drug": "RPV",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "98G+227C",
+    "drug": "DOR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "98G+227C",
+    "drug": "EFV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "98G+227C",
+    "drug": "ETR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "98G+227C",
+    "drug": "NVP",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "rule": "98G+227C",
+    "drug": "RPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "11IL+32I",
+    "drug": "DRV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "11IL+32I",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "11IL+32I",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "11IL+32I",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "11IL+32I",
+    "drug": "NFV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "11IL+54LM",
+    "drug": "DRV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "11IL+54LM",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "11IL+54LM",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "11IL+54LM",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "11IL+54LM",
+    "drug": "NFV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+47AV",
+    "drug": "ATV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+47AV",
+    "drug": "DRV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+47AV",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+47AV",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+47AV",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+47AV",
+    "drug": "NFV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+54LM",
+    "drug": "ATV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+54LM",
+    "drug": "DRV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+54LM",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+54LM",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+54LM",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+54LM",
+    "drug": "NFV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+76V",
+    "drug": "DRV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+76V",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+76V",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+76V",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+76V",
+    "drug": "NFV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+84V",
+    "drug": "DRV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+84V",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+84V",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+84V",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+84V",
+    "drug": "NFV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+89V",
+    "drug": "DRV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+89V",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+89V",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+89V",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "32I+89V",
+    "drug": "NFV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46IL+84V+90M",
+    "drug": "ATV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46IL+84V+90M",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46IL+84V+90M",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46IL+84V+90M",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46IL+84V+90M",
+    "drug": "NFV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46IL+84V+90M",
+    "drug": "SQV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46IL+84V+90M",
+    "drug": "TPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46ILV+76V",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46ILV+76V",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46ILV+76V",
+    "drug": "LPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46ILV+76V",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46ILV+82ACFLMST",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46ILV+82ACFLMST",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46ILV+82ACFLMST",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46ILV+82ACFLMST",
+    "drug": "LPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46ILV+82ACFLMST",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46ILV+82ACFLMST",
+    "drug": "SQV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46ILV+90M",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46ILV+90M",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46ILV+90M",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46ILV+90M",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "46ILV+90M",
+    "drug": "SQV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "47AV+54LM",
+    "drug": "ATV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "47AV+54LM",
+    "drug": "DRV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "47AV+54LM",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "47AV+54LM",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "47AV+54LM",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "47AV+54LM",
+    "drug": "NFV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "47AV+84V",
+    "drug": "DRV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "47AV+84V",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "47AV+84V",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "47AV+84V",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "47AV+84V",
+    "drug": "NFV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "53L+90M",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "53L+90M",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "53L+90M",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "53L+90M",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "53L+90M",
+    "drug": "SQV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54ALMSTV+82ACFLMST",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54ALMSTV+82ACFLMST",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54ALMSTV+82ACFLMST",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54ALMSTV+82ACFLMST",
+    "drug": "LPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54ALMSTV+82ACFLMST",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54ALMSTV+82ACFLMST",
+    "drug": "SQV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54ALMSTV+90M",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54ALMSTV+90M",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54ALMSTV+90M",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54ALMSTV+90M",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54ALMSTV+90M",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54ALMSTV+90M",
+    "drug": "SQV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54LM+84V",
+    "drug": "DRV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54LM+84V",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54LM+84V",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54LM+84V",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54LM+84V",
+    "drug": "NFV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54LM+89V",
+    "drug": "DRV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54LM+89V",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54LM+89V",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54LM+89V",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "54LM+89V",
+    "drug": "NFV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "73ACSTV+90M",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "73ACSTV+90M",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "73ACSTV+90M",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "73ACSTV+90M",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "73ACSTV+90M",
+    "drug": "SQV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "82ACFLMST+90M",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "82ACFLMST+90M",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "82ACFLMST+90M",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "82ACFLMST+90M",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "82ACFLMST+90M",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "rule": "82ACFLMST+90M",
+    "drug": "SQV",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "118R+138AKT",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "118R+138AKT",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "118R+138AKT",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "118R+138AKT",
+    "drug": "RAL",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "138AKT+140ACS",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "138AKT+140ACS",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "138AKT+140ACS",
+    "drug": "EVG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "138AKT+140ACS",
+    "drug": "RAL",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "138AKT+148HKR",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "138AKT+148HKR",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "140ACS+148HKR",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "140ACS+148HKR",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "140ACS+148HKR+149A",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "140ACS+148HKR+149A",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "140ACS+148HKR+149A",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "140ACS+148HKR+149A",
+    "drug": "RAL",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "143ACGHRS+163R",
+    "drug": "BIC",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "143ACGHRS+163R",
+    "drug": "DTG",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "143ACGHRS+163R",
+    "drug": "EVG",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "143ACGHRS+230R",
+    "drug": "BIC",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "143ACGHRS+230R",
+    "drug": "DTG",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "143ACGHRS+230R",
+    "drug": "EVG",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "147G+148HKR",
+    "drug": "BIC",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "147G+148HKR",
+    "drug": "DTG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "148HKR+155H",
+    "drug": "BIC",
+    "score": 20
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "148HKR+155H",
+    "drug": "DTG",
+    "score": 20
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "148HKR+163KR",
+    "drug": "BIC",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "148HKR+163KR",
+    "drug": "DTG",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "155H+147G",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "155H+147G",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "155H+147G",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "155H+263K",
+    "drug": "BIC",
+    "score": 20
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "155H+263K",
+    "drug": "DTG",
+    "score": 20
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "157Q+263K",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "157Q+263K",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "51Y+263K",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "51Y+263K",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "51Y+263K",
+    "drug": "EVG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "74FIM+118R",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "74FIM+118R",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "74FIM+118R",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "74FIM+118R",
+    "drug": "RAL",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "74FIM+143ACGHRS",
+    "drug": "BIC",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "74FIM+143ACGHRS",
+    "drug": "DTG",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "74FIM+143ACGHRS",
+    "drug": "EVG",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "74FIM+148HKR",
+    "drug": "BIC",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "74FIM+148HKR",
+    "drug": "DTG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "74FIM+148HKR",
+    "drug": "EVG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "74FIM+148HKR",
+    "drug": "RAL",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "92Q+155H",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "92Q+155H",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "92Q+155H",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "92Q+155H",
+    "drug": "RAL",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "97A+118R",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "97A+118R",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "97A+118R",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "97A+118R",
+    "drug": "RAL",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "97A+143ACGHRS",
+    "drug": "EVG",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "97A+148HKR",
+    "drug": "BIC",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "rule": "97A+148HKR",
+    "drug": "DTG",
+    "score": 15
+  }
+]

--- a/data/mutation-scores-indiv.json
+++ b/data/mutation-scores-indiv.json
@@ -1,0 +1,7698 @@
+[
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 41,
+    "aa": "L",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 41,
+    "aa": "L",
+    "drug": "AZT",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 41,
+    "aa": "L",
+    "drug": "D4T",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 41,
+    "aa": "L",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 41,
+    "aa": "L",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 62,
+    "aa": "V",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 62,
+    "aa": "V",
+    "drug": "AZT",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 62,
+    "aa": "V",
+    "drug": "D4T",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 62,
+    "aa": "V",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 62,
+    "aa": "V",
+    "drug": "FTC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 62,
+    "aa": "V",
+    "drug": "LMV",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 62,
+    "aa": "V",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "E",
+    "drug": "ABC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "E",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "E",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "E",
+    "drug": "TDF",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "N",
+    "drug": "ABC",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "N",
+    "drug": "AZT",
+    "score": -10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "N",
+    "drug": "D4T",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "N",
+    "drug": "DDI",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "N",
+    "drug": "FTC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "N",
+    "drug": "LMV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "N",
+    "drug": "TDF",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "R",
+    "drug": "ABC",
+    "score": 45
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "R",
+    "drug": "AZT",
+    "score": -15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "R",
+    "drug": "D4T",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "R",
+    "drug": "DDI",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "R",
+    "drug": "FTC",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "R",
+    "drug": "LMV",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 65,
+    "aa": "R",
+    "drug": "TDF",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "E",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "E",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "E",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "E",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "E",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "G",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "G",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "G",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "G",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "G",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "H",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "H",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "H",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "H",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "H",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "N",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "N",
+    "drug": "AZT",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "N",
+    "drug": "D4T",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "N",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "N",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "S",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "S",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "S",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "S",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "S",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "T",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "T",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "T",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "T",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "T",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "-",
+    "drug": "ABC",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "-",
+    "drug": "AZT",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "-",
+    "drug": "D4T",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "-",
+    "drug": "DDI",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "-",
+    "drug": "FTC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "-",
+    "drug": "LMV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 67,
+    "aa": "-",
+    "drug": "TDF",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 68,
+    "aa": "-",
+    "drug": "ABC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 68,
+    "aa": "-",
+    "drug": "D4T",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 68,
+    "aa": "-",
+    "drug": "DDI",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 68,
+    "aa": "-",
+    "drug": "FTC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 68,
+    "aa": "-",
+    "drug": "LMV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 68,
+    "aa": "-",
+    "drug": "TDF",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "D",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "D",
+    "drug": "DDI",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "G",
+    "drug": "ABC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "G",
+    "drug": "AZT",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "G",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "G",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "G",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "_",
+    "drug": "ABC",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "_",
+    "drug": "AZT",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "_",
+    "drug": "D4T",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "_",
+    "drug": "DDI",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "_",
+    "drug": "FTC",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "_",
+    "drug": "LMV",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "_",
+    "drug": "TDF",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "-",
+    "drug": "ABC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "-",
+    "drug": "D4T",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "-",
+    "drug": "DDI",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "-",
+    "drug": "FTC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "-",
+    "drug": "LMV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 69,
+    "aa": "-",
+    "drug": "TDF",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "E",
+    "drug": "ABC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "E",
+    "drug": "AZT",
+    "score": -10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "E",
+    "drug": "D4T",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "E",
+    "drug": "DDI",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "E",
+    "drug": "FTC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "E",
+    "drug": "LMV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "E",
+    "drug": "TDF",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "G",
+    "drug": "ABC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "G",
+    "drug": "AZT",
+    "score": -10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "G",
+    "drug": "D4T",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "G",
+    "drug": "DDI",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "G",
+    "drug": "FTC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "G",
+    "drug": "LMV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "G",
+    "drug": "TDF",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "N",
+    "drug": "ABC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "N",
+    "drug": "D4T",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "N",
+    "drug": "DDI",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "N",
+    "drug": "FTC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "N",
+    "drug": "LMV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "N",
+    "drug": "TDF",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "Q",
+    "drug": "ABC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "Q",
+    "drug": "D4T",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "Q",
+    "drug": "DDI",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "Q",
+    "drug": "FTC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "Q",
+    "drug": "LMV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "Q",
+    "drug": "TDF",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "R",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "R",
+    "drug": "AZT",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "R",
+    "drug": "D4T",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "R",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "R",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "S",
+    "drug": "ABC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "S",
+    "drug": "D4T",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "S",
+    "drug": "DDI",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "S",
+    "drug": "FTC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "S",
+    "drug": "LMV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "S",
+    "drug": "TDF",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "T",
+    "drug": "ABC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "T",
+    "drug": "D4T",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "T",
+    "drug": "DDI",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "T",
+    "drug": "FTC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "T",
+    "drug": "LMV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "T",
+    "drug": "TDF",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "-",
+    "drug": "ABC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "-",
+    "drug": "D4T",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "-",
+    "drug": "DDI",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "-",
+    "drug": "FTC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "-",
+    "drug": "LMV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 70,
+    "aa": "-",
+    "drug": "TDF",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 74,
+    "aa": "I",
+    "drug": "ABC",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 74,
+    "aa": "I",
+    "drug": "DDI",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 74,
+    "aa": "I",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 74,
+    "aa": "V",
+    "drug": "ABC",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 74,
+    "aa": "V",
+    "drug": "DDI",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 75,
+    "aa": "A",
+    "drug": "D4T",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 75,
+    "aa": "A",
+    "drug": "DDI",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 75,
+    "aa": "I",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 75,
+    "aa": "I",
+    "drug": "AZT",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 75,
+    "aa": "I",
+    "drug": "D4T",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 75,
+    "aa": "I",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 75,
+    "aa": "I",
+    "drug": "FTC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 75,
+    "aa": "I",
+    "drug": "LMV",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 75,
+    "aa": "I",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 75,
+    "aa": "M",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 75,
+    "aa": "M",
+    "drug": "D4T",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 75,
+    "aa": "M",
+    "drug": "DDI",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 75,
+    "aa": "S",
+    "drug": "D4T",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 75,
+    "aa": "S",
+    "drug": "DDI",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 75,
+    "aa": "T",
+    "drug": "D4T",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 75,
+    "aa": "T",
+    "drug": "DDI",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 77,
+    "aa": "L",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 77,
+    "aa": "L",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 77,
+    "aa": "L",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 77,
+    "aa": "L",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 77,
+    "aa": "L",
+    "drug": "FTC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 77,
+    "aa": "L",
+    "drug": "LMV",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 77,
+    "aa": "L",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 98,
+    "aa": "G",
+    "drug": "DOR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 98,
+    "aa": "G",
+    "drug": "EFV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 98,
+    "aa": "G",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 98,
+    "aa": "G",
+    "drug": "NVP",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 98,
+    "aa": "G",
+    "drug": "RPV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 100,
+    "aa": "I",
+    "drug": "DOR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 100,
+    "aa": "I",
+    "drug": "EFV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 100,
+    "aa": "I",
+    "drug": "ETR",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 100,
+    "aa": "I",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 100,
+    "aa": "I",
+    "drug": "RPV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 100,
+    "aa": "V",
+    "drug": "DOR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 100,
+    "aa": "V",
+    "drug": "EFV",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 100,
+    "aa": "V",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 100,
+    "aa": "V",
+    "drug": "NVP",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 100,
+    "aa": "V",
+    "drug": "RPV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 101,
+    "aa": "E",
+    "drug": "DOR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 101,
+    "aa": "E",
+    "drug": "EFV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 101,
+    "aa": "E",
+    "drug": "ETR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 101,
+    "aa": "E",
+    "drug": "NVP",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 101,
+    "aa": "E",
+    "drug": "RPV",
+    "score": 45
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 101,
+    "aa": "H",
+    "drug": "EFV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 101,
+    "aa": "H",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 101,
+    "aa": "H",
+    "drug": "NVP",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 101,
+    "aa": "H",
+    "drug": "RPV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 101,
+    "aa": "P",
+    "drug": "DOR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 101,
+    "aa": "P",
+    "drug": "EFV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 101,
+    "aa": "P",
+    "drug": "ETR",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 101,
+    "aa": "P",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 101,
+    "aa": "P",
+    "drug": "RPV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 103,
+    "aa": "H",
+    "drug": "EFV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 103,
+    "aa": "H",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 103,
+    "aa": "N",
+    "drug": "EFV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 103,
+    "aa": "N",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 103,
+    "aa": "S",
+    "drug": "EFV",
+    "score": 45
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 103,
+    "aa": "S",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 103,
+    "aa": "T",
+    "drug": "EFV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 103,
+    "aa": "T",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 106,
+    "aa": "A",
+    "drug": "DOR",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 106,
+    "aa": "A",
+    "drug": "EFV",
+    "score": 45
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 106,
+    "aa": "A",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 106,
+    "aa": "I",
+    "drug": "DOR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 106,
+    "aa": "I",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 106,
+    "aa": "I",
+    "drug": "NVP",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 106,
+    "aa": "I",
+    "drug": "RPV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 106,
+    "aa": "M",
+    "drug": "DOR",
+    "score": 50
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 106,
+    "aa": "M",
+    "drug": "EFV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 106,
+    "aa": "M",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 108,
+    "aa": "I",
+    "drug": "DOR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 108,
+    "aa": "I",
+    "drug": "EFV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 108,
+    "aa": "I",
+    "drug": "NVP",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 115,
+    "aa": "F",
+    "drug": "ABC",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 115,
+    "aa": "F",
+    "drug": "TDF",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 116,
+    "aa": "Y",
+    "drug": "ABC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 116,
+    "aa": "Y",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 116,
+    "aa": "Y",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 116,
+    "aa": "Y",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 116,
+    "aa": "Y",
+    "drug": "FTC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 116,
+    "aa": "Y",
+    "drug": "LMV",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 116,
+    "aa": "Y",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "A",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "A",
+    "drug": "RPV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "G",
+    "drug": "EFV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "G",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "G",
+    "drug": "NVP",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "G",
+    "drug": "RPV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "K",
+    "drug": "DOR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "K",
+    "drug": "EFV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "K",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "K",
+    "drug": "NVP",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "K",
+    "drug": "RPV",
+    "score": 45
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "Q",
+    "drug": "EFV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "Q",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "Q",
+    "drug": "NVP",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "Q",
+    "drug": "RPV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "R",
+    "drug": "EFV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "R",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "R",
+    "drug": "NVP",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 138,
+    "aa": "R",
+    "drug": "RPV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 151,
+    "aa": "L",
+    "drug": "ABC",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 151,
+    "aa": "L",
+    "drug": "AZT",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 151,
+    "aa": "L",
+    "drug": "D4T",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 151,
+    "aa": "L",
+    "drug": "DDI",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 151,
+    "aa": "L",
+    "drug": "FTC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 151,
+    "aa": "L",
+    "drug": "LMV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 151,
+    "aa": "L",
+    "drug": "TDF",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 151,
+    "aa": "M",
+    "drug": "ABC",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 151,
+    "aa": "M",
+    "drug": "AZT",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 151,
+    "aa": "M",
+    "drug": "D4T",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 151,
+    "aa": "M",
+    "drug": "DDI",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 151,
+    "aa": "M",
+    "drug": "FTC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 151,
+    "aa": "M",
+    "drug": "LMV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 151,
+    "aa": "M",
+    "drug": "TDF",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "D",
+    "drug": "EFV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "D",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "D",
+    "drug": "NVP",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "D",
+    "drug": "RPV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "E",
+    "drug": "EFV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "E",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "E",
+    "drug": "NVP",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "E",
+    "drug": "RPV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "F",
+    "drug": "DOR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "F",
+    "drug": "EFV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "F",
+    "drug": "ETR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "F",
+    "drug": "NVP",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "F",
+    "drug": "RPV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "L",
+    "drug": "EFV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "L",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "L",
+    "drug": "NVP",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 179,
+    "aa": "L",
+    "drug": "RPV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "C",
+    "drug": "DOR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "C",
+    "drug": "EFV",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "C",
+    "drug": "ETR",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "C",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "C",
+    "drug": "RPV",
+    "score": 45
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "F",
+    "drug": "EFV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "F",
+    "drug": "ETR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "F",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "F",
+    "drug": "RPV",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "G",
+    "drug": "EFV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "G",
+    "drug": "ETR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "G",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "G",
+    "drug": "RPV",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "I",
+    "drug": "DOR",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "I",
+    "drug": "EFV",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "I",
+    "drug": "ETR",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "I",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "I",
+    "drug": "RPV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "S",
+    "drug": "EFV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "S",
+    "drug": "ETR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "S",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "S",
+    "drug": "RPV",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "V",
+    "drug": "DOR",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "V",
+    "drug": "EFV",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "V",
+    "drug": "ETR",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "V",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 181,
+    "aa": "V",
+    "drug": "RPV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 184,
+    "aa": "I",
+    "drug": "ABC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 184,
+    "aa": "I",
+    "drug": "AZT",
+    "score": -10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 184,
+    "aa": "I",
+    "drug": "D4T",
+    "score": -10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 184,
+    "aa": "I",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 184,
+    "aa": "I",
+    "drug": "FTC",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 184,
+    "aa": "I",
+    "drug": "LMV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 184,
+    "aa": "I",
+    "drug": "TDF",
+    "score": -10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 184,
+    "aa": "V",
+    "drug": "ABC",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 184,
+    "aa": "V",
+    "drug": "AZT",
+    "score": -10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 184,
+    "aa": "V",
+    "drug": "D4T",
+    "score": -10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 184,
+    "aa": "V",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 184,
+    "aa": "V",
+    "drug": "FTC",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 184,
+    "aa": "V",
+    "drug": "LMV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 184,
+    "aa": "V",
+    "drug": "TDF",
+    "score": -10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 188,
+    "aa": "C",
+    "drug": "DOR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 188,
+    "aa": "C",
+    "drug": "EFV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 188,
+    "aa": "C",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 188,
+    "aa": "F",
+    "drug": "DOR",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 188,
+    "aa": "F",
+    "drug": "EFV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 188,
+    "aa": "F",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 188,
+    "aa": "F",
+    "drug": "RPV",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 188,
+    "aa": "H",
+    "drug": "DOR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 188,
+    "aa": "H",
+    "drug": "EFV",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 188,
+    "aa": "H",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 188,
+    "aa": "L",
+    "drug": "DOR",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 188,
+    "aa": "L",
+    "drug": "EFV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 188,
+    "aa": "L",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 188,
+    "aa": "L",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 188,
+    "aa": "L",
+    "drug": "RPV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "A",
+    "drug": "EFV",
+    "score": 45
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "A",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "A",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "A",
+    "drug": "RPV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "C",
+    "drug": "DOR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "C",
+    "drug": "EFV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "C",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "C",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "C",
+    "drug": "RPV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "E",
+    "drug": "DOR",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "E",
+    "drug": "EFV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "E",
+    "drug": "ETR",
+    "score": 45
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "E",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "E",
+    "drug": "RPV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "Q",
+    "drug": "DOR",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "Q",
+    "drug": "EFV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "Q",
+    "drug": "ETR",
+    "score": 45
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "Q",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "Q",
+    "drug": "RPV",
+    "score": 45
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "S",
+    "drug": "DOR",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "S",
+    "drug": "EFV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "S",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "S",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "S",
+    "drug": "RPV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "T",
+    "drug": "DOR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "T",
+    "drug": "EFV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "T",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "T",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "T",
+    "drug": "RPV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "V",
+    "drug": "DOR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "V",
+    "drug": "EFV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "V",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "V",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 190,
+    "aa": "V",
+    "drug": "RPV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 210,
+    "aa": "W",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 210,
+    "aa": "W",
+    "drug": "AZT",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 210,
+    "aa": "W",
+    "drug": "D4T",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 210,
+    "aa": "W",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 210,
+    "aa": "W",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "A",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "A",
+    "drug": "AZT",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "A",
+    "drug": "D4T",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "A",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "A",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "C",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "C",
+    "drug": "AZT",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "C",
+    "drug": "D4T",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "C",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "C",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "D",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "D",
+    "drug": "AZT",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "D",
+    "drug": "D4T",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "D",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "D",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "E",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "E",
+    "drug": "AZT",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "E",
+    "drug": "D4T",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "E",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "E",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "F",
+    "drug": "ABC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "F",
+    "drug": "AZT",
+    "score": 40
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "F",
+    "drug": "D4T",
+    "score": 40
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "F",
+    "drug": "DDI",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "F",
+    "drug": "TDF",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "I",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "I",
+    "drug": "AZT",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "I",
+    "drug": "D4T",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "I",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "I",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "L",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "L",
+    "drug": "AZT",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "L",
+    "drug": "D4T",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "L",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "L",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "N",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "N",
+    "drug": "AZT",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "N",
+    "drug": "D4T",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "N",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "N",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "S",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "S",
+    "drug": "AZT",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "S",
+    "drug": "D4T",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "S",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "S",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "V",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "V",
+    "drug": "AZT",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "V",
+    "drug": "D4T",
+    "score": 20
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "V",
+    "drug": "DDI",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "V",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "Y",
+    "drug": "ABC",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "Y",
+    "drug": "AZT",
+    "score": 40
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "Y",
+    "drug": "D4T",
+    "score": 40
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "Y",
+    "drug": "DDI",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 215,
+    "aa": "Y",
+    "drug": "TDF",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "E",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "E",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "E",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "E",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "E",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "N",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "N",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "N",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "N",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "N",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "Q",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "Q",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "Q",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "Q",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "Q",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "R",
+    "drug": "ABC",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "R",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "R",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "R",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "R",
+    "drug": "TDF",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "W",
+    "drug": "AZT",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "W",
+    "drug": "D4T",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NRTI",
+    "pos": 219,
+    "aa": "W",
+    "drug": "DDI",
+    "score": 5
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 221,
+    "aa": "Y",
+    "drug": "DOR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 221,
+    "aa": "Y",
+    "drug": "EFV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 221,
+    "aa": "Y",
+    "drug": "ETR",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 221,
+    "aa": "Y",
+    "drug": "NVP",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 221,
+    "aa": "Y",
+    "drug": "RPV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 225,
+    "aa": "H",
+    "drug": "DOR",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 225,
+    "aa": "H",
+    "drug": "EFV",
+    "score": 45
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 225,
+    "aa": "H",
+    "drug": "NVP",
+    "score": 45
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 227,
+    "aa": "C",
+    "drug": "DOR",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 227,
+    "aa": "C",
+    "drug": "EFV",
+    "score": 45
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 227,
+    "aa": "C",
+    "drug": "ETR",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 227,
+    "aa": "C",
+    "drug": "NVP",
+    "score": 45
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 227,
+    "aa": "C",
+    "drug": "RPV",
+    "score": 45
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 227,
+    "aa": "I",
+    "drug": "DOR",
+    "score": 50
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 227,
+    "aa": "I",
+    "drug": "EFV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 227,
+    "aa": "I",
+    "drug": "NVP",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 227,
+    "aa": "L",
+    "drug": "DOR",
+    "score": 50
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 227,
+    "aa": "L",
+    "drug": "EFV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 227,
+    "aa": "L",
+    "drug": "NVP",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 227,
+    "aa": "V",
+    "drug": "DOR",
+    "score": 50
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 227,
+    "aa": "V",
+    "drug": "EFV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 227,
+    "aa": "V",
+    "drug": "NVP",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 230,
+    "aa": "I",
+    "drug": "DOR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 230,
+    "aa": "I",
+    "drug": "EFV",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 230,
+    "aa": "I",
+    "drug": "ETR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 230,
+    "aa": "I",
+    "drug": "NVP",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 230,
+    "aa": "I",
+    "drug": "RPV",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 230,
+    "aa": "L",
+    "drug": "DOR",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 230,
+    "aa": "L",
+    "drug": "EFV",
+    "score": 45
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 230,
+    "aa": "L",
+    "drug": "ETR",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 230,
+    "aa": "L",
+    "drug": "NVP",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 230,
+    "aa": "L",
+    "drug": "RPV",
+    "score": 60
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 234,
+    "aa": "I",
+    "drug": "DOR",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 236,
+    "aa": "L",
+    "drug": "DOR",
+    "score": 15
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 238,
+    "aa": "N",
+    "drug": "EFV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 238,
+    "aa": "N",
+    "drug": "NVP",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 238,
+    "aa": "T",
+    "drug": "EFV",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 238,
+    "aa": "T",
+    "drug": "NVP",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 318,
+    "aa": "F",
+    "drug": "DOR",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 318,
+    "aa": "F",
+    "drug": "EFV",
+    "score": 10
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 318,
+    "aa": "F",
+    "drug": "NVP",
+    "score": 30
+  },
+  {
+    "gene": "RT",
+    "drugClass": "NNRTI",
+    "pos": 348,
+    "aa": "I",
+    "drug": "NVP",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 10,
+    "aa": "F",
+    "drug": "DRV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 10,
+    "aa": "F",
+    "drug": "FPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 10,
+    "aa": "F",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 10,
+    "aa": "F",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 10,
+    "aa": "F",
+    "drug": "NFV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 20,
+    "aa": "T",
+    "drug": "ATV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 20,
+    "aa": "T",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 20,
+    "aa": "T",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 20,
+    "aa": "T",
+    "drug": "NFV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 20,
+    "aa": "T",
+    "drug": "SQV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 23,
+    "aa": "I",
+    "drug": "NFV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "F",
+    "drug": "ATV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "F",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "F",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "F",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "F",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "F",
+    "drug": "SQV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "I",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "I",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "I",
+    "drug": "IDV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "I",
+    "drug": "LPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "I",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "I",
+    "drug": "SQV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "I",
+    "drug": "TPV",
+    "score": -5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "M",
+    "drug": "ATV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "M",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "M",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "M",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "M",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 24,
+    "aa": "M",
+    "drug": "SQV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 30,
+    "aa": "N",
+    "drug": "NFV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 32,
+    "aa": "I",
+    "drug": "ATV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 32,
+    "aa": "I",
+    "drug": "DRV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 32,
+    "aa": "I",
+    "drug": "FPV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 32,
+    "aa": "I",
+    "drug": "IDV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 32,
+    "aa": "I",
+    "drug": "LPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 32,
+    "aa": "I",
+    "drug": "NFV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 32,
+    "aa": "I",
+    "drug": "TPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 33,
+    "aa": "F",
+    "drug": "ATV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 33,
+    "aa": "F",
+    "drug": "DRV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 33,
+    "aa": "F",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 33,
+    "aa": "F",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 33,
+    "aa": "F",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 33,
+    "aa": "F",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 33,
+    "aa": "F",
+    "drug": "SQV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 33,
+    "aa": "F",
+    "drug": "TPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 43,
+    "aa": "T",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 43,
+    "aa": "T",
+    "drug": "TPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "I",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "I",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "I",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "I",
+    "drug": "LPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "I",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "I",
+    "drug": "SQV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "I",
+    "drug": "TPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "L",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "L",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "L",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "L",
+    "drug": "LPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "L",
+    "drug": "NFV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "L",
+    "drug": "SQV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "L",
+    "drug": "TPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "V",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "V",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "V",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "V",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "V",
+    "drug": "NFV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "V",
+    "drug": "SQV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 46,
+    "aa": "V",
+    "drug": "TPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 47,
+    "aa": "A",
+    "drug": "DRV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 47,
+    "aa": "A",
+    "drug": "FPV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 47,
+    "aa": "A",
+    "drug": "IDV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 47,
+    "aa": "A",
+    "drug": "LPV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 47,
+    "aa": "A",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 47,
+    "aa": "A",
+    "drug": "TPV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 47,
+    "aa": "V",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 47,
+    "aa": "V",
+    "drug": "DRV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 47,
+    "aa": "V",
+    "drug": "FPV",
+    "score": 35
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 47,
+    "aa": "V",
+    "drug": "IDV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 47,
+    "aa": "V",
+    "drug": "LPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 47,
+    "aa": "V",
+    "drug": "NFV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 47,
+    "aa": "V",
+    "drug": "TPV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "A",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "A",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "A",
+    "drug": "LPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "A",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "A",
+    "drug": "SQV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "L",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "L",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "L",
+    "drug": "LPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "L",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "L",
+    "drug": "SQV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "M",
+    "drug": "ATV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "M",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "M",
+    "drug": "LPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "M",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "M",
+    "drug": "SQV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "Q",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "Q",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "Q",
+    "drug": "LPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "Q",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "Q",
+    "drug": "SQV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "S",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "S",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "S",
+    "drug": "LPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "S",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "S",
+    "drug": "SQV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "T",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "T",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "T",
+    "drug": "LPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "T",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "T",
+    "drug": "SQV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "V",
+    "drug": "ATV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "V",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "V",
+    "drug": "LPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "V",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 48,
+    "aa": "V",
+    "drug": "SQV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 50,
+    "aa": "L",
+    "drug": "ATV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 50,
+    "aa": "L",
+    "drug": "DRV",
+    "score": -10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 50,
+    "aa": "L",
+    "drug": "FPV",
+    "score": -5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 50,
+    "aa": "L",
+    "drug": "IDV",
+    "score": -5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 50,
+    "aa": "L",
+    "drug": "LPV",
+    "score": -10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 50,
+    "aa": "L",
+    "drug": "SQV",
+    "score": -5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 50,
+    "aa": "L",
+    "drug": "TPV",
+    "score": -5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 50,
+    "aa": "V",
+    "drug": "DRV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 50,
+    "aa": "V",
+    "drug": "FPV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 50,
+    "aa": "V",
+    "drug": "LPV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 50,
+    "aa": "V",
+    "drug": "NFV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 50,
+    "aa": "V",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 50,
+    "aa": "V",
+    "drug": "TPV",
+    "score": -5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 53,
+    "aa": "L",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 53,
+    "aa": "L",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 53,
+    "aa": "L",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "A",
+    "drug": "ATV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "A",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "A",
+    "drug": "IDV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "A",
+    "drug": "LPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "A",
+    "drug": "NFV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "A",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "A",
+    "drug": "TPV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "L",
+    "drug": "ATV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "L",
+    "drug": "DRV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "L",
+    "drug": "FPV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "L",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "L",
+    "drug": "LPV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "L",
+    "drug": "NFV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "L",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "L",
+    "drug": "TPV",
+    "score": -10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "M",
+    "drug": "ATV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "M",
+    "drug": "DRV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "M",
+    "drug": "FPV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "M",
+    "drug": "IDV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "M",
+    "drug": "LPV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "M",
+    "drug": "NFV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "M",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "M",
+    "drug": "TPV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "S",
+    "drug": "ATV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "S",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "S",
+    "drug": "IDV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "S",
+    "drug": "LPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "S",
+    "drug": "NFV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "S",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "S",
+    "drug": "TPV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "T",
+    "drug": "ATV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "T",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "T",
+    "drug": "IDV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "T",
+    "drug": "LPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "T",
+    "drug": "NFV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "T",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "T",
+    "drug": "TPV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "V",
+    "drug": "ATV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "V",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "V",
+    "drug": "IDV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "V",
+    "drug": "LPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "V",
+    "drug": "NFV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "V",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 54,
+    "aa": "V",
+    "drug": "TPV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 58,
+    "aa": "E",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 58,
+    "aa": "E",
+    "drug": "TPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "A",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "A",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "A",
+    "drug": "IDV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "A",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "A",
+    "drug": "NFV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "A",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "C",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "C",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "C",
+    "drug": "IDV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "C",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "C",
+    "drug": "NFV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "C",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "D",
+    "drug": "ATV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "D",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "D",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "D",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "D",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "D",
+    "drug": "SQV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "S",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "S",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "S",
+    "drug": "IDV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "S",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "S",
+    "drug": "NFV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "S",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "T",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "T",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "T",
+    "drug": "IDV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "T",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "T",
+    "drug": "NFV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "T",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "V",
+    "drug": "ATV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "V",
+    "drug": "FPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "V",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "V",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "V",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 73,
+    "aa": "V",
+    "drug": "SQV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 74,
+    "aa": "P",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 74,
+    "aa": "P",
+    "drug": "DRV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 74,
+    "aa": "P",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 74,
+    "aa": "P",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 74,
+    "aa": "P",
+    "drug": "LPV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 74,
+    "aa": "P",
+    "drug": "NFV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 74,
+    "aa": "P",
+    "drug": "SQV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 74,
+    "aa": "P",
+    "drug": "TPV",
+    "score": 25
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 76,
+    "aa": "V",
+    "drug": "DRV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 76,
+    "aa": "V",
+    "drug": "FPV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 76,
+    "aa": "V",
+    "drug": "IDV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 76,
+    "aa": "V",
+    "drug": "LPV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 76,
+    "aa": "V",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 76,
+    "aa": "V",
+    "drug": "TPV",
+    "score": -5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "A",
+    "drug": "ATV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "A",
+    "drug": "FPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "A",
+    "drug": "IDV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "A",
+    "drug": "LPV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "A",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "A",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "C",
+    "drug": "ATV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "C",
+    "drug": "FPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "C",
+    "drug": "IDV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "C",
+    "drug": "LPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "C",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "C",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "C",
+    "drug": "TPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "F",
+    "drug": "ATV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "F",
+    "drug": "DRV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "F",
+    "drug": "FPV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "F",
+    "drug": "IDV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "F",
+    "drug": "LPV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "F",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "F",
+    "drug": "SQV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "L",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "L",
+    "drug": "FPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "L",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "L",
+    "drug": "LPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "L",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "L",
+    "drug": "SQV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "L",
+    "drug": "TPV",
+    "score": 45
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "M",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "M",
+    "drug": "FPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "M",
+    "drug": "IDV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "M",
+    "drug": "LPV",
+    "score": 25
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "M",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "M",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "M",
+    "drug": "TPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "S",
+    "drug": "ATV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "S",
+    "drug": "FPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "S",
+    "drug": "IDV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "S",
+    "drug": "LPV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "S",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "S",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "S",
+    "drug": "TPV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "T",
+    "drug": "ATV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "T",
+    "drug": "FPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "T",
+    "drug": "IDV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "T",
+    "drug": "LPV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "T",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "T",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 82,
+    "aa": "T",
+    "drug": "TPV",
+    "score": 45
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 83,
+    "aa": "D",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 83,
+    "aa": "D",
+    "drug": "IDV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 83,
+    "aa": "D",
+    "drug": "NFV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 83,
+    "aa": "D",
+    "drug": "SQV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 83,
+    "aa": "D",
+    "drug": "TPV",
+    "score": 25
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "A",
+    "drug": "ATV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "A",
+    "drug": "DRV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "A",
+    "drug": "FPV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "A",
+    "drug": "IDV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "A",
+    "drug": "LPV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "A",
+    "drug": "NFV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "A",
+    "drug": "SQV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "A",
+    "drug": "TPV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "C",
+    "drug": "ATV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "C",
+    "drug": "DRV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "C",
+    "drug": "FPV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "C",
+    "drug": "IDV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "C",
+    "drug": "LPV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "C",
+    "drug": "NFV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "C",
+    "drug": "SQV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "C",
+    "drug": "TPV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "V",
+    "drug": "ATV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "V",
+    "drug": "DRV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "V",
+    "drug": "FPV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "V",
+    "drug": "IDV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "V",
+    "drug": "LPV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "V",
+    "drug": "NFV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "V",
+    "drug": "SQV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 84,
+    "aa": "V",
+    "drug": "TPV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 88,
+    "aa": "D",
+    "drug": "ATV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 88,
+    "aa": "D",
+    "drug": "NFV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 88,
+    "aa": "D",
+    "drug": "SQV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 88,
+    "aa": "G",
+    "drug": "ATV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 88,
+    "aa": "G",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 88,
+    "aa": "S",
+    "drug": "ATV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 88,
+    "aa": "S",
+    "drug": "DRV",
+    "score": -5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 88,
+    "aa": "S",
+    "drug": "FPV",
+    "score": -10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 88,
+    "aa": "S",
+    "drug": "IDV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 88,
+    "aa": "S",
+    "drug": "NFV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 88,
+    "aa": "S",
+    "drug": "SQV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 88,
+    "aa": "T",
+    "drug": "ATV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 88,
+    "aa": "T",
+    "drug": "NFV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 89,
+    "aa": "V",
+    "drug": "DRV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 89,
+    "aa": "V",
+    "drug": "FPV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 89,
+    "aa": "V",
+    "drug": "IDV",
+    "score": 5
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 89,
+    "aa": "V",
+    "drug": "NFV",
+    "score": 10
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 90,
+    "aa": "M",
+    "drug": "ATV",
+    "score": 25
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 90,
+    "aa": "M",
+    "drug": "FPV",
+    "score": 20
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 90,
+    "aa": "M",
+    "drug": "IDV",
+    "score": 30
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 90,
+    "aa": "M",
+    "drug": "LPV",
+    "score": 15
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 90,
+    "aa": "M",
+    "drug": "NFV",
+    "score": 60
+  },
+  {
+    "gene": "PR",
+    "drugClass": "PI",
+    "pos": 90,
+    "aa": "M",
+    "drug": "SQV",
+    "score": 45
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 51,
+    "aa": "Y",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 51,
+    "aa": "Y",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 51,
+    "aa": "Y",
+    "drug": "EVG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 51,
+    "aa": "Y",
+    "drug": "RAL",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 66,
+    "aa": "A",
+    "drug": "EVG",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 66,
+    "aa": "A",
+    "drug": "RAL",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 66,
+    "aa": "I",
+    "drug": "BIC",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 66,
+    "aa": "I",
+    "drug": "DTG",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 66,
+    "aa": "I",
+    "drug": "EVG",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 66,
+    "aa": "I",
+    "drug": "RAL",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 66,
+    "aa": "K",
+    "drug": "BIC",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 66,
+    "aa": "K",
+    "drug": "DTG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 66,
+    "aa": "K",
+    "drug": "EVG",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 66,
+    "aa": "K",
+    "drug": "RAL",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 92,
+    "aa": "G",
+    "drug": "EVG",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 92,
+    "aa": "G",
+    "drug": "RAL",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 92,
+    "aa": "Q",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 92,
+    "aa": "Q",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 92,
+    "aa": "Q",
+    "drug": "EVG",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 92,
+    "aa": "Q",
+    "drug": "RAL",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 92,
+    "aa": "V",
+    "drug": "EVG",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 92,
+    "aa": "V",
+    "drug": "RAL",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 95,
+    "aa": "K",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 95,
+    "aa": "K",
+    "drug": "RAL",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 97,
+    "aa": "A",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 97,
+    "aa": "A",
+    "drug": "RAL",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 118,
+    "aa": "R",
+    "drug": "BIC",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 118,
+    "aa": "R",
+    "drug": "DTG",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 118,
+    "aa": "R",
+    "drug": "EVG",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 118,
+    "aa": "R",
+    "drug": "RAL",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 121,
+    "aa": "Y",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 121,
+    "aa": "Y",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 121,
+    "aa": "Y",
+    "drug": "EVG",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 121,
+    "aa": "Y",
+    "drug": "RAL",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 138,
+    "aa": "A",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 138,
+    "aa": "A",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 138,
+    "aa": "A",
+    "drug": "EVG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 138,
+    "aa": "A",
+    "drug": "RAL",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 138,
+    "aa": "K",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 138,
+    "aa": "K",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 138,
+    "aa": "K",
+    "drug": "EVG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 138,
+    "aa": "K",
+    "drug": "RAL",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 138,
+    "aa": "T",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 138,
+    "aa": "T",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 138,
+    "aa": "T",
+    "drug": "EVG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 138,
+    "aa": "T",
+    "drug": "RAL",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 140,
+    "aa": "A",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 140,
+    "aa": "A",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 140,
+    "aa": "A",
+    "drug": "EVG",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 140,
+    "aa": "A",
+    "drug": "RAL",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 140,
+    "aa": "C",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 140,
+    "aa": "C",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 140,
+    "aa": "C",
+    "drug": "EVG",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 140,
+    "aa": "C",
+    "drug": "RAL",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 140,
+    "aa": "S",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 140,
+    "aa": "S",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 140,
+    "aa": "S",
+    "drug": "EVG",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 140,
+    "aa": "S",
+    "drug": "RAL",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "A",
+    "drug": "BIC",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "A",
+    "drug": "DTG",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "A",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "A",
+    "drug": "RAL",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "C",
+    "drug": "BIC",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "C",
+    "drug": "DTG",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "C",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "C",
+    "drug": "RAL",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "G",
+    "drug": "BIC",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "G",
+    "drug": "DTG",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "G",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "G",
+    "drug": "RAL",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "H",
+    "drug": "BIC",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "H",
+    "drug": "DTG",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "H",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "H",
+    "drug": "RAL",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "K",
+    "drug": "BIC",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "K",
+    "drug": "DTG",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "K",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "K",
+    "drug": "RAL",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "R",
+    "drug": "BIC",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "R",
+    "drug": "DTG",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "R",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "R",
+    "drug": "RAL",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "S",
+    "drug": "BIC",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "S",
+    "drug": "DTG",
+    "score": 5
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "S",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 143,
+    "aa": "S",
+    "drug": "RAL",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 145,
+    "aa": "S",
+    "drug": "EVG",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 146,
+    "aa": "P",
+    "drug": "EVG",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 147,
+    "aa": "G",
+    "drug": "EVG",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 148,
+    "aa": "H",
+    "drug": "BIC",
+    "score": 25
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 148,
+    "aa": "H",
+    "drug": "DTG",
+    "score": 25
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 148,
+    "aa": "H",
+    "drug": "EVG",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 148,
+    "aa": "H",
+    "drug": "RAL",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 148,
+    "aa": "K",
+    "drug": "BIC",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 148,
+    "aa": "K",
+    "drug": "DTG",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 148,
+    "aa": "K",
+    "drug": "EVG",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 148,
+    "aa": "K",
+    "drug": "RAL",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 148,
+    "aa": "N",
+    "drug": "EVG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 148,
+    "aa": "N",
+    "drug": "RAL",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 148,
+    "aa": "R",
+    "drug": "BIC",
+    "score": 25
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 148,
+    "aa": "R",
+    "drug": "DTG",
+    "score": 25
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 148,
+    "aa": "R",
+    "drug": "EVG",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 148,
+    "aa": "R",
+    "drug": "RAL",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 151,
+    "aa": "A",
+    "drug": "EVG",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 151,
+    "aa": "A",
+    "drug": "RAL",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 151,
+    "aa": "L",
+    "drug": "BIC",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 151,
+    "aa": "L",
+    "drug": "DTG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 151,
+    "aa": "L",
+    "drug": "EVG",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 151,
+    "aa": "L",
+    "drug": "RAL",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 153,
+    "aa": "F",
+    "drug": "BIC",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 153,
+    "aa": "F",
+    "drug": "DTG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 153,
+    "aa": "F",
+    "drug": "EVG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 153,
+    "aa": "Y",
+    "drug": "BIC",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 153,
+    "aa": "Y",
+    "drug": "DTG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 153,
+    "aa": "Y",
+    "drug": "EVG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 155,
+    "aa": "H",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 155,
+    "aa": "H",
+    "drug": "DTG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 155,
+    "aa": "H",
+    "drug": "EVG",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 155,
+    "aa": "H",
+    "drug": "RAL",
+    "score": 60
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 155,
+    "aa": "S",
+    "drug": "EVG",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 155,
+    "aa": "S",
+    "drug": "RAL",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 155,
+    "aa": "T",
+    "drug": "EVG",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 155,
+    "aa": "T",
+    "drug": "RAL",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 157,
+    "aa": "Q",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 157,
+    "aa": "Q",
+    "drug": "RAL",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 163,
+    "aa": "K",
+    "drug": "EVG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 163,
+    "aa": "K",
+    "drug": "RAL",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 163,
+    "aa": "R",
+    "drug": "EVG",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 163,
+    "aa": "R",
+    "drug": "RAL",
+    "score": 15
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 230,
+    "aa": "R",
+    "drug": "BIC",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 230,
+    "aa": "R",
+    "drug": "DTG",
+    "score": 20
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 230,
+    "aa": "R",
+    "drug": "EVG",
+    "score": 20
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 230,
+    "aa": "R",
+    "drug": "RAL",
+    "score": 20
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 232,
+    "aa": "N",
+    "drug": "EVG",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 232,
+    "aa": "N",
+    "drug": "RAL",
+    "score": 10
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 263,
+    "aa": "K",
+    "drug": "BIC",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 263,
+    "aa": "K",
+    "drug": "DTG",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 263,
+    "aa": "K",
+    "drug": "EVG",
+    "score": 30
+  },
+  {
+    "gene": "IN",
+    "drugClass": "INSTI",
+    "pos": 263,
+    "aa": "K",
+    "drug": "RAL",
+    "score": 25
+  }
+]

--- a/scripts/construct_hivdb_asi.py
+++ b/scripts/construct_hivdb_asi.py
@@ -1,0 +1,537 @@
+#! /usr/bin/env python3
+from pathlib import Path
+from collections import defaultdict
+from collections import OrderedDict
+from functools import lru_cache
+import yaml
+from yaml import Loader
+import json
+import re
+
+from lxml import etree
+from lxml.builder import E
+
+import click
+
+
+# File configuration & ASI file version
+BASEDIR = Path(__file__).parent.parent.absolute()
+DATADIR = BASEDIR / 'data'
+VERSIONS_PATH = BASEDIR / 'data' / 'algorithms' / 'versions.yml'
+
+
+@lru_cache()
+def get_versions():
+    with VERSIONS_PATH.open() as fp:
+        versions = yaml.load(fp, Loader=Loader)
+
+        return versions
+
+
+_VERSION = None
+
+
+def get_cur_version():
+    if not _VERSION:
+        version = get_versions()['HIVDB'][-1]
+    else:
+        match = re.match(r'(\d+)[.\-_](\d+)[.\-_]?(\d+)?', _VERSION)
+        if not match:
+            raise Exception(
+                'Version {} is not a well-formed version.'.format(version))
+        major, middle, minor = match.groups()
+        search_version = major + '.' + middle
+        if minor:
+            search_version += '-' + minor
+
+        for item in get_versions()['HIVDB']:
+            if item[0] == search_version:
+                version = item
+                break
+        else:
+            raise Exception('Version {} not found.'.format(version))
+
+    return dict(zip(
+        ['version', 'date', 'type'],
+        version
+        ))
+
+
+# Load data
+class DataSource(type):
+
+    def __init__(self, name, bases, attrs):
+        file_name = attrs.get('FILENAME')
+        if not file_name:
+            return
+        else:
+            file_path = DATADIR / file_name
+
+            with open(file_path) as fd:
+                self.DATA = json.load(fd)
+
+
+class DrugClassData(metaclass=DataSource):
+
+    FILENAME = 'drug-classes.json'
+
+    @classmethod
+    def gene_definition(cls):
+        _gene_definition = defaultdict(list)
+        for drugclass in cls.DATA:
+            gene = drugclass['abstractGene']
+            _gene_definition[gene].append(drugclass['name'])
+
+        return _gene_definition
+
+
+class DrugData(metaclass=DataSource):
+
+    FILENAME = 'drugs.json'
+    DRUGCLASS_ORDER = [
+        'NRTI',
+        'NNRTI',
+        'PI',
+        'INSTI'
+    ]
+
+    @classmethod
+    def drugclass(cls):
+        _drugclass = defaultdict(list)
+
+        for drug in cls.DATA:
+            drugclass = drug['drugClass']
+
+            _drugclass[drugclass].append(drug)
+
+        return OrderedDict(sorted(
+                _drugclass.items(),
+                key=lambda i: cls.DRUGCLASS_ORDER.index(i[0]))
+            )
+
+    @classmethod
+    def get_display_abbr(cls, drugname):
+        for item in cls.DATA:
+            if item['name'] == drugname:
+                return item['displayAbbr']
+
+
+class ConditionalCommentData(metaclass=DataSource):
+
+    FILENAME = 'conditional-comments.json'
+
+    @classmethod
+    def get_comments_by(cls, condtype):
+        _data = [
+            item for item in cls.DATA
+            if item['conditionType'] == condtype
+        ]
+        if condtype == 'DRUGLEVEL':
+            comments = _data
+        else:
+            comments = defaultdict(list)
+            for comment in _data:
+                gene = comment['conditionValue']['gene']
+                comments[gene].append(comment)
+
+        return comments
+
+
+def filter_out_HIV2(cls):
+    _DATA = []
+    for comment in cls.DATA:
+        if comment['strain'].startswith('HIV2'):
+            continue
+        else:
+            _DATA.append(comment)
+
+    return _DATA
+
+
+ConditionalCommentData.DATA = filter_out_HIV2(ConditionalCommentData)
+
+
+class MutationComments(metaclass=DataSource):
+
+    @classmethod
+    def get_by_drugname(cls, drugname):
+        rules = cls._filtered_rules = []
+
+        for rule in cls.DATA:
+            if rule['drug'] == drugname:
+                rules.append(rule)
+
+        return cls
+
+    @classmethod
+    def group_by_position(cls):
+        rules = defaultdict(list)
+
+        for rule in cls._filtered_rules:
+            pos = rule['pos']
+            rules[pos].append(rule)
+
+        return rules
+
+
+class MutationIndivComments(MutationComments):
+
+    FILENAME = 'mutation-scores-indiv.json'
+
+
+class MutationCombiComments(MutationComments):
+
+    FILENAME = 'mutation-scores-combi.json'
+    MUTATION_PATTERN = r'(\d+)([A-Z]+)'
+
+    @classmethod
+    def group_and_order_by_position(cls):
+        rules = defaultdict(list)
+
+        for item in cls._filtered_rules:
+            rule_list = item['rule'].split('+')
+            positions = []
+            for mut in rule_list:
+                position = re.match(cls.MUTATION_PATTERN, mut).group(1)
+                positions.append(position)
+
+            rules[','.join(positions)].append(item)
+
+        single_rule = []
+        multi_rule = []
+
+        for key, item in rules.items():
+            if len(item) == 1:
+                single_rule.append([key, item])
+            else:
+                multi_rule.append([key, item])
+
+        return single_rule + multi_rule
+
+
+# Algorithm constants
+ALG_NAME = "HIVDB"
+
+
+LEVEL_DEFINITION = [
+    ["Susceptible", "S", '1'],
+    ["Potential Low-Level Resistance", "S", '2'],
+    ["Low-Level Resistance", "I", '3'],
+    ["Intermediate Resistance", "I", '4'],
+    ["High-Level Resistance", "R", '5'],
+]
+
+GLOBALRANGE_CONTENTS = (
+    "(-INF TO 9 => 1,  "
+    "10 TO 14 => 2,  "
+    "15 TO 29 => 3,  "
+    "30 TO 59 => 4,  "
+    "60 TO INF => 5)"
+)
+DRUG_RULE_INDENTATION = ' ' * 25
+
+
+# Util function
+def to_asi_format(aa):
+    aa = aa.replace(
+        '#', 'i').replace(
+        '_', 'i').replace(
+        '~', 'd').replace(
+        '-', 'd')
+
+    return aa
+
+
+# ASI file parts
+def doc_type(name, pubid, system):
+    if pubid:
+        return '<!DOCTYPE {name} {type} "{pubid}" "{system}">'.format(
+            name=name,
+            type='PUBLIC',
+            pubid=pubid,
+            system=system
+        )
+    else:
+        return '<!DOCTYPE {name} {type} "{system}">'.format(
+            name=name,
+            type='SYSTEM',
+            system=system
+        )
+
+
+# Definitions
+def gene_definition(tree):
+    for gene, drugs in DrugClassData.gene_definition().items():
+        tree.append(
+            E.GENE_DEFINITION(
+                E.NAME(gene),
+                E.DRUGCLASSLIST(','.join(drugs))
+            )
+        )
+
+
+def level_definition(tree):
+    for item in LEVEL_DEFINITION:
+        _ = etree.SubElement(tree, 'LEVEL_DEFINITION')
+
+        etree.SubElement(_, 'ORDER').text = item[-1]
+        etree.SubElement(_, 'ORIGINAL').text = item[0]
+        etree.SubElement(_, 'SIR').text = item[1]
+
+
+def drugclass_definition(tree):
+    for drugclass, drugs in DrugData.drugclass().items():
+        drugs = [i['displayAbbr'] for i in drugs]
+        tree.append(
+            E.DRUGCLASS(
+                E.NAME(drugclass),
+                E.DRUGLIST(
+                    ','.join(drugs)
+                )
+            )
+
+        )
+
+
+def global_range_definition():
+    return E.GLOBALRANGE(
+            etree.CDATA(GLOBALRANGE_CONTENTS)
+        )
+
+
+def comment_definitions():
+    tree = E.COMMENT_DEFINITIONS()
+
+    for comment in ConditionalCommentData.DATA:
+        tree.append(
+            E.COMMENT_STRING(
+                E.TEXT(etree.CDATA(comment['comment'])),
+                E.SORT_TAG('1'),
+                id=comment['commentName'],
+            )
+        )
+
+    return tree
+
+
+def definition():
+    tree = E('DEFINITIONS')
+
+    gene_definition(tree)
+    level_definition(tree)
+    drugclass_definition(tree)
+
+    tree.append(global_range_definition())
+    tree.append(comment_definitions())
+
+    return tree
+
+
+# Drug
+def drug_rules(drugname):
+    all_rules = []
+
+    # individual rule
+    rules = MutationIndivComments.get_by_drugname(
+        drugname).group_by_position()
+
+    for pos, _ in rules.items():
+        _rules = []
+        for rule in _:
+            aa = to_asi_format(rule['aa'])
+            score = rule['score']
+            _rules.append(
+                '{}{} => {}'.format(pos, aa, score)
+            )
+        if len(_rules) == 1:
+            all_rules.append(''.join(_rules))
+        else:
+            all_rules.append('MAX ( ' + ', '.join(_rules) + ' )')
+
+    # Combinational rule
+    rules = MutationCombiComments.get_by_drugname(
+        drugname).group_and_order_by_position()
+
+    for _, rule_list in rules:
+        _rules = []
+        for _ in rule_list:
+            rule = _['rule'].replace('+', ' AND ')
+            rule = to_asi_format(rule)
+            score = _['score']
+
+            rule = '({}) => {}'.format(rule, score)
+            _rules.append(rule)
+
+        if len(_rules) == 1:
+            all_rules.append(''.join(_rules))
+        else:
+            all_rules.append('MAX (' + ', '.join(_rules) + ')')
+
+    ident = ',\n' + DRUG_RULE_INDENTATION
+
+    cc = (
+        "SCORE FROM(" +
+        ident.join(all_rules) +
+        ")"
+    )
+    return cc
+
+
+def drug(tree):
+
+    for drugclass, drugs in DrugData.drugclass().items():
+        for drug in drugs:
+            drug_node = E(
+                'DRUG',
+                E.NAME(drug['displayAbbr']),
+                E.FULLNAME(drug['fullName']),
+                E.RULE(
+                    E.CONDITION(
+                        etree.CDATA(drug_rules(drug['name']))
+                    ),
+                    E(
+                        'ACTIONS',
+                        E(
+                            'SCORERANGE',
+                            E('USE_GLOBALRANGE')
+                        )
+                    )
+                )
+            )
+
+            tree.append(drug_node)
+
+    return None
+
+
+def mutation_comment(tree):
+    comments_node = E('MUTATION_COMMENTS')
+
+    mutation_comments = ConditionalCommentData.get_comments_by('MUTATION')
+
+    for gene, comments in mutation_comments.items():
+        gene_node = E(
+            'GENE',
+            E('NAME', gene)
+        )
+
+        for comment in comments:
+            rule_node = E(
+                'RULE',
+                E(
+                    'CONDITION',
+                    '{}{}'.format(
+                        comment['conditionValue']['pos'],
+                        to_asi_format(comment['conditionValue']['aas'])
+                    )
+                ),
+                E(
+                    'ACTIONS',
+                    E('COMMENT', ref=comment['commentName'])
+                )
+            )
+
+            gene_node.append(rule_node)
+
+        comments_node.append(gene_node)
+
+    tree.append(comments_node)
+
+
+def result_comments():
+    tree = E('RESULT_COMMENTS')
+
+    for comment in ConditionalCommentData.get_comments_by('DRUGLEVEL'):
+        rule_node = E('RESULT_COMMENT_RULE')
+        condition = E('DRUG_LEVEL_CONDITIONS')
+
+        cond_value = comment['conditionValue']
+        if 'and' not in cond_value:
+            cond_value = [cond_value]
+        else:
+            cond_value = cond_value['and']
+
+        for value in cond_value:
+            for level in value['levels']:
+                drugname = DrugData.get_display_abbr(value['drug'])
+                condition.append(E.DRUG_LEVEL_CONDITION(
+                    E.DRUG_NAME(drugname),
+                    E.EQ(str(level))
+                ))
+
+        rule_node.append(condition)
+        rule_node.append(
+            E.LEVEL_ACTION(
+                E.COMMENT(ref=comment['commentName'])
+            )
+        )
+        tree.append(rule_node)
+
+    return tree
+
+
+# Assemble content
+def algorithm():
+
+    tree = E.ALGORITHM(
+        E.ALGNAME(ALG_NAME),
+        E.ALGVERSION(get_cur_version()['version']),
+        E.ALGDATE(get_cur_version()['date']),
+        definition()
+    )
+
+    drug(tree)
+    mutation_comment(tree)
+    tree.append(result_comments())
+
+    return tree
+
+
+DEFAULT_OUTPUT_FOLDER = BASEDIR / 'data' / 'algorithms'
+DEFAULT_OUTPUT_PATH = 'HIVDB_{}.xml'.format(get_cur_version()['version'])
+
+
+def output(content, output_path=None):
+    # First line, change from single quote to double quote
+    lines = content.split('\n')
+    for _, line in enumerate(lines):
+        if _ == 0:
+            line = line.replace('\'', '"')
+            lines[_] = line
+
+    if not output_path:
+        output_path = DEFAULT_OUTPUT_PATH
+    else:
+        output_path = output_path[0]
+
+    output_path = DEFAULT_OUTPUT_FOLDER / output_path
+
+    with output_path.open('w') as fd:
+        fd.write('\n'.join(lines))
+
+
+@click.command()
+@click.argument('output_path', nargs=-1)
+@click.option('--version')
+def work(output_path, version):
+    global _VERSION
+    _VERSION = version
+
+    result = etree.tostring(
+        algorithm(),
+        pretty_print=True,
+        xml_declaration=True,
+        encoding='UTF-8',
+        standalone=False,
+        doctype=doc_type(
+            'ALGORITHM',
+            '',
+            'https://cms.hivdb.org/prod/downloads/asi/ASI2.2.dtd'
+        )
+    )
+
+    output(result.decode('utf-8'), output_path)
+
+
+if __name__ == "__main__":
+    work()

--- a/scripts/export_mut_scores_combi.py
+++ b/scripts/export_mut_scores_combi.py
@@ -1,0 +1,63 @@
+#! /usr/bin/env python3
+import os
+import json
+import yaml
+import click
+from yaml import Loader
+from sqlalchemy import create_engine
+
+BASEDIR = os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__))
+)
+VERSIONS_PATH = os.path.join(
+    BASEDIR, 'data', 'algorithms', 'versions.yml')
+
+DATABASE_URI = os.environ.get(
+    'DATABASE_URI_HIVDBRULES',
+    'mysql+pymysql://rshafer:rshafer@10.77.6.244/HIVDB_Results'
+)
+QUERY_TBL_COMBISCORE = (
+    "SELECT Gene, DrugClass, Rule, Drug, Score "
+    "FROM tblCombinationScoresWithVersions WHERE Version=%s "
+    "ORDER BY Gene, Rule, Drug;"
+)
+
+
+def get_latest_db_version():
+    with open(VERSIONS_PATH) as fp:
+        data = yaml.load(fp, Loader=Loader)
+        ver, *_ = data['HIVDB'][-1]
+        return 'V' + ver.split('-', 1)[0].replace('.', '_')
+
+
+def to_internalformat(aa):
+    aa = aa.replace(
+        'i', '_').replace(
+        '#', '_').replace(
+        'd', '-').replace(
+        '~', '-')
+
+    return aa
+
+
+@click.command()
+@click.argument('output_json', type=click.File('w'))
+def main(output_json):
+    engine = create_engine(DATABASE_URI)
+    engine.connect()
+    dbver = get_latest_db_version()
+    results = engine.execute(QUERY_TBL_COMBISCORE, dbver)
+    cmtlist = []
+    for row in results:
+        cmtlist.append({
+            'gene': row['Gene'],
+            'drugClass': row['DrugClass'],
+            'rule': to_internalformat(row['Rule']),
+            'drug': row['Drug'],
+            'score': row['Score']
+        })
+    json.dump(cmtlist, output_json, indent=2)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/export_mut_scores_indiv.py
+++ b/scripts/export_mut_scores_indiv.py
@@ -1,0 +1,64 @@
+#! /usr/bin/env python3
+import os
+import json
+import yaml
+import click
+from yaml import Loader
+from sqlalchemy import create_engine
+
+BASEDIR = os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__))
+)
+VERSIONS_PATH = os.path.join(
+    BASEDIR, 'data', 'algorithms', 'versions.yml')
+
+DATABASE_URI = os.environ.get(
+    'DATABASE_URI_HIVDBRULES',
+    'mysql+pymysql://rshafer:rshafer@10.77.6.244/HIVDB_Results'
+)
+QUERY_TBL_SCORE = (
+    "SELECT Gene, DrugClass, Pos, AA, Drug, Score "
+    "FROM tblScoresWithVersions WHERE Version=%s "
+    "ORDER BY Gene, Pos, AA, Drug;"
+)
+
+
+def get_latest_db_version():
+    with open(VERSIONS_PATH) as fp:
+        data = yaml.load(fp, Loader=Loader)
+        ver, *_ = data['HIVDB'][-1]
+        return 'V' + ver.split('-', 1)[0].replace('.', '_')
+
+
+def to_internalformat(aa):
+    aa = aa.replace(
+        'i', '_').replace(
+        '#', '_').replace(
+        'd', '-').replace(
+        '~', '-')
+
+    return aa
+
+
+@click.command()
+@click.argument('output_json', type=click.File('w'))
+def main(output_json):
+    engine = create_engine(DATABASE_URI)
+    engine.connect()
+    dbver = get_latest_db_version()
+    results = engine.execute(QUERY_TBL_SCORE, dbver)
+    cmtlist = []
+    for row in results:
+        cmtlist.append({
+            'gene': row['Gene'],
+            'drugClass': row['DrugClass'],
+            'pos': row['Pos'],
+            'aa': to_internalformat(row['AA']),
+            'drug': row['Drug'],
+            'score': row['Score'],
+        })
+    json.dump(cmtlist, output_json, indent=2)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/update-mut-scores.sh
+++ b/scripts/update-mut-scores.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+BASEDIR=`realpath $(dirname $0)/..`
+DATADIR="$BASEDIR/data"
+
+set -e
+cd $BASEDIR
+
+pipenv run python3 scripts/export_mut_scores_indiv.py $DATADIR/mutation-scores-indiv.json
+pipenv run python3 scripts/export_mut_scores_combi.py $DATADIR/mutation-scores-combi.json


### PR DESCRIPTION
- Pipfile and pipfile.lock is updated, adding lxml, and pipenv automatically updated some package
- Add json data which contains content related to ASI file generation
- Add export scripts for generate json data files
- add *construct_hivdb_asi.py* script for generating ASI file
```shell
Usage: construct_hivdb_asi.py [OPTIONS] [OUTPUT_PATH]...

Options:
  --version TEXT
  --help          Show this message and exit.
```

====
- Basic function is tested
- Flake8 is tested